### PR TITLE
feat: implement webhook event handling for Hyperswitch plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,11 +22,11 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill-oss-parent</artifactId>
-        <version>0.146.6</version>
+        <version>0.146.7</version>
     </parent>
     <groupId>io.github.juspay.hyperswitchplugin</groupId>
     <artifactId>hyperswitch-killbill-plugin</artifactId>
-    <version>0.1.1</version>
+    <version>0.1.2</version>
     <packaging>bundle</packaging>
     <name>Kill Bill OSGI Hyperswitch bundle</name>
     <description>Kill Bill Hyperswitch plugin</description>

--- a/src/main/java/org/killbill/billing/plugin/hyperswitch/HyperswitchActivator.java
+++ b/src/main/java/org/killbill/billing/plugin/hyperswitch/HyperswitchActivator.java
@@ -30,6 +30,7 @@ import org.killbill.billing.invoice.plugin.api.InvoicePluginApi;
 import org.killbill.billing.osgi.api.Healthcheck;
 import org.killbill.billing.osgi.api.OSGIPluginProperties;
 import org.killbill.billing.osgi.libs.killbill.KillbillActivatorBase;
+import org.killbill.billing.osgi.libs.killbill.OSGIKillbillClock;
 import org.killbill.billing.osgi.libs.killbill.OSGIKillbillEventDispatcher;
 import org.killbill.billing.osgi.libs.killbill.OSGIKillbillEventDispatcher.OSGIFrameworkEventHandler;
 import org.killbill.billing.payment.plugin.api.PaymentPluginApi;
@@ -54,7 +55,7 @@ public class HyperswitchActivator extends KillbillActivatorBase {
         super.start(context);
 
         final String region = PluginEnvironmentConfig.getRegion(configProperties.getProperties());
-        final HyperswitchDao hyperswitchDao = new HyperswitchDao(dataSource.getDataSource());
+        final HyperswitchDao hyperswitchDao = new HyperswitchDao(dataSource.getDataSource(), clock.getClock());
         logger.info(" starting plugin {}", PLUGIN_NAME);
         // Register an event listener for plugin configuration (optional)
         logger.info("Registering an event listener for plugin configuration");
@@ -70,6 +71,7 @@ public class HyperswitchActivator extends KillbillActivatorBase {
         logger.info("Registering an APIs");
         final PaymentPluginApi paymentPluginApi = new HyperswitchPaymentPluginApi(hyperswitchConfigurationHandler,killbillAPI,configProperties,clock.getClock(),hyperswitchDao);
         registerPaymentPluginApi(context, paymentPluginApi);
+
 
         logger.info("Registering healthcheck");
         // Expose a healthcheck (optional), so other plugins can check on the plugin status

--- a/src/main/java/org/killbill/billing/plugin/hyperswitch/HyperswitchConfigProperties.java
+++ b/src/main/java/org/killbill/billing/plugin/hyperswitch/HyperswitchConfigProperties.java
@@ -35,26 +35,28 @@ public class HyperswitchConfigProperties {
 
 
 	public static final String HYPERSWITCH_API_KEY = "HYPERSWITCH_API_KEY";
-	public static final String HYPERSWITCH_PROFILE_ID= "HYPERSWITCH_PROFILE_ID";
-	public static final String HPYERSWITCH_ENVIRONMENT_KEY = "HPYERSWITCH_ENVIRONMENT";
+	public static final String HYPERSWITCH_PROFILE_ID = "HYPERSWITCH_PROFILE_ID";
+	public static final String HYPERSWITCH_ENVIRONMENT_KEY = "HYPERSWITCH_ENVIRONMENT";
+	public static final String HYPERSWITCH_WEBHOOK_SECRET = "HYPERSWITCH_WEBHOOK_SECRET";
 
 
 	private final String hyperswitchApikey;
 	private final String environment;
 	private final String profileId;
-    
+	private final String webhookSecret = null;
+
 
 	public enum Environment {
-		PRODUCTION, 
+		PRODUCTION,
 		SANDBOX
 	}
-	
+
 	public HyperswitchConfigProperties(final Properties properties, final String region) {
 		this.hyperswitchApikey = properties.getProperty(PROPERTY_PREFIX + "hyperswitchApikey");
 		this.profileId = properties.getProperty(PROPERTY_PREFIX + "profileId");
 		this.environment = properties.getProperty(PROPERTY_PREFIX + "environment", "sandbox"); // defaults to sandbox
 	}
-	
+
 
 	public String getHSApiKey() {
 		if (hyperswitchApikey == null || hyperswitchApikey.isEmpty()) {
@@ -62,21 +64,28 @@ public class HyperswitchConfigProperties {
 		}
 		return hyperswitchApikey;
 	}
-	
+
 	public String getEnvironment() {
 		if (environment == null || environment.isEmpty()) {
 			return getClient(environment, null);
 		}
 		return environment;
 	}
-	
+
 	public String getProfileId(){
 		if (profileId == null || profileId.isEmpty()) {
 			return getClient(profileId, null);
 		}
 		return profileId;
 	}
-	
+
+	public String getWebhookSecret() {
+		if (webhookSecret == null || webhookSecret.isEmpty()) {
+			return getClient(HYPERSWITCH_WEBHOOK_SECRET, null);
+		}
+		return webhookSecret;
+	}
+
 	private String getClient(String envKey, String defaultValue) {
 		Map<String, String> env = System.getenv();
 
@@ -87,6 +96,6 @@ public class HyperswitchConfigProperties {
 		}
 
 		return value;
-	}	
+	}
 
 }

--- a/src/main/java/org/killbill/billing/plugin/hyperswitch/HyperswitchGatewayNotification.java
+++ b/src/main/java/org/killbill/billing/plugin/hyperswitch/HyperswitchGatewayNotification.java
@@ -1,0 +1,41 @@
+package org.killbill.billing.plugin.hyperswitch;
+
+import org.killbill.billing.payment.api.PluginProperty;
+import org.killbill.billing.payment.plugin.api.GatewayNotification;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+public class HyperswitchGatewayNotification implements GatewayNotification {
+    private final UUID kbPaymentId;
+
+    public HyperswitchGatewayNotification(UUID kbPaymentId) {
+        this.kbPaymentId = kbPaymentId;
+    }
+
+    @Override
+    public UUID getKbPaymentId() {
+        return kbPaymentId;
+    }
+
+    @Override
+    public int getStatus() {
+        return 200;
+    }
+
+    @Override
+    public String getEntity() {
+        return null;
+    }
+
+    @Override
+    public Map<String, List<String>> getHeaders() {
+        return Map.of();
+    }
+
+    @Override
+    public List<PluginProperty> getProperties() {
+        return List.of();
+    }
+}

--- a/src/main/java/org/killbill/billing/plugin/hyperswitch/HyperswitchPaymentTransactionInfoPlugin.java
+++ b/src/main/java/org/killbill/billing/plugin/hyperswitch/HyperswitchPaymentTransactionInfoPlugin.java
@@ -34,7 +34,6 @@ import org.killbill.billing.plugin.hyperswitch.dao.gen.tables.records.Hyperswitc
 import com.google.common.base.Strings;
 
 public class HyperswitchPaymentTransactionInfoPlugin extends PluginPaymentTransactionInfoPlugin {
-	private final HyperswitchResponsesRecord hyperswitchResponseRecord;
 
 	public static HyperswitchPaymentTransactionInfoPlugin build(
 			final HyperswitchResponsesRecord HyperswitchResponsesRecord) {
@@ -72,7 +71,6 @@ public class HyperswitchPaymentTransactionInfoPlugin extends PluginPaymentTransa
 		super(kbPaymentId, kbTransactionPaymentPaymentId, transactionType, amount, currency, pluginStatus, gatewayError,
 				gatewayErrorCode, firstPaymentReferenceId, secondPaymentReferenceId, createdDate, effectiveDate,
 				properties);
-		this.hyperswitchResponseRecord = hyperswitchResponsesRecord;
 	}
 
 	public static PaymentTransactionInfoPlugin cancelPaymentTransactionInfoPlugin(
@@ -99,11 +97,15 @@ public class HyperswitchPaymentTransactionInfoPlugin extends PluginPaymentTransa
         final String status = (String) additionalData.get("status");
         if ("succeeded".equals(status) || "requires_capture".equals(status)) {
             return PaymentPluginStatus.PROCESSED;
-        } else if("cancelled".equals(status)) {
-			return PaymentPluginStatus.CANCELED;
-		}
-		else if ("processing".equals(status)) {
+        } else if ("processing".equals(status) || 
+                   "requires_payment_method".equals(status) ||
+                   "requires_confirmation".equals(status) ||
+                   "requires_customer_action".equals(status)) {
             return PaymentPluginStatus.PENDING;
+        } else if ("failed".equals(status)) {
+            return PaymentPluginStatus.ERROR;
+        } else if ("cancelled".equals(status)) {
+            return PaymentPluginStatus.CANCELED;
         } else {
             return PaymentPluginStatus.UNDEFINED;
         }

--- a/src/main/java/org/killbill/billing/plugin/hyperswitch/dao/gen/Indexes.java
+++ b/src/main/java/org/killbill/billing/plugin/hyperswitch/dao/gen/Indexes.java
@@ -10,7 +10,7 @@ import org.jooq.impl.Internal;
 import org.killbill.billing.plugin.hyperswitch.dao.gen.tables.HyperswitchHppRequests;
 import org.killbill.billing.plugin.hyperswitch.dao.gen.tables.HyperswitchPaymentMethods;
 import org.killbill.billing.plugin.hyperswitch.dao.gen.tables.HyperswitchResponses;
-
+import org.killbill.billing.plugin.hyperswitch.dao.gen.tables.HyperswitchWebhookEvents;
 
 /**
  * A class modelling indexes of tables of the <code>killbill</code> schema.
@@ -28,6 +28,9 @@ public class Indexes {
     public static final Index HYPERSWITCH_RESPONSES_HYPERSWITCH_RESPONSES_KB_PAYMENT_ID = Indexes0.HYPERSWITCH_RESPONSES_HYPERSWITCH_RESPONSES_KB_PAYMENT_ID;
     public static final Index HYPERSWITCH_RESPONSES_HYPERSWITCH_RESPONSES_KB_PAYMENT_TRANSACTION_ID = Indexes0.HYPERSWITCH_RESPONSES_HYPERSWITCH_RESPONSES_KB_PAYMENT_TRANSACTION_ID;
     public static final Index HYPERSWITCH_RESPONSES_HYPERSWITCH_RESPONSES_PAYMENT_ATTEMPT_ID = Indexes0.HYPERSWITCH_RESPONSES_HYPERSWITCH_RESPONSES_PAYMENT_ATTEMPT_ID;
+    public static final Index HYPERSWITCH_WEBHOOK_EVENTS_PAYMENT = Indexes0.HYPERSWITCH_WEBHOOK_EVENTS_PAYMENT;
+    public static final Index HYPERSWITCH_WEBHOOK_EVENTS_TRANSACTION = Indexes0.HYPERSWITCH_WEBHOOK_EVENTS_TRANSACTION;
+    public static final Index HYPERSWITCH_WEBHOOK_EVENTS_HYPERSWITCH_ID = Indexes0.HYPERSWITCH_WEBHOOK_EVENTS_HYPERSWITCH_ID;
 
     // -------------------------------------------------------------------------
     // [#1459] distribute members to avoid static initialisers > 64kb
@@ -40,5 +43,8 @@ public class Indexes {
         public static Index HYPERSWITCH_RESPONSES_HYPERSWITCH_RESPONSES_KB_PAYMENT_ID = Internal.createIndex("hyperswitch_responses_kb_payment_id", HyperswitchResponses.HYPERSWITCH_RESPONSES, new OrderField[] { HyperswitchResponses.HYPERSWITCH_RESPONSES.KB_PAYMENT_ID }, false);
         public static Index HYPERSWITCH_RESPONSES_HYPERSWITCH_RESPONSES_KB_PAYMENT_TRANSACTION_ID = Internal.createIndex("hyperswitch_responses_kb_payment_transaction_id", HyperswitchResponses.HYPERSWITCH_RESPONSES, new OrderField[] { HyperswitchResponses.HYPERSWITCH_RESPONSES.KB_PAYMENT_TRANSACTION_ID }, false);
         public static Index HYPERSWITCH_RESPONSES_HYPERSWITCH_RESPONSES_PAYMENT_ATTEMPT_ID = Internal.createIndex("hyperswitch_responses_hyperswitch_id", HyperswitchResponses.HYPERSWITCH_RESPONSES, new OrderField[] { HyperswitchResponses.HYPERSWITCH_RESPONSES.PAYMENT_ATTEMPT_ID }, false);
+        public static Index HYPERSWITCH_WEBHOOK_EVENTS_PAYMENT = Internal.createIndex("hyperswitch_webhook_events_payment", HyperswitchWebhookEvents.HYPERSWITCH_WEBHOOK_EVENTS, new OrderField[] {HyperswitchWebhookEvents.HYPERSWITCH_WEBHOOK_EVENTS.KB_PAYMENT_ID }, false);
+        public static Index HYPERSWITCH_WEBHOOK_EVENTS_TRANSACTION = Internal.createIndex("hyperswitch_webhook_events_transaction", HyperswitchWebhookEvents.HYPERSWITCH_WEBHOOK_EVENTS, new OrderField[] { HyperswitchWebhookEvents.HYPERSWITCH_WEBHOOK_EVENTS.KB_PAYMENT_TRANSACTION_ID }, false);
+        public static Index HYPERSWITCH_WEBHOOK_EVENTS_HYPERSWITCH_ID = Internal.createIndex("hyperswitch_webhook_events_hyperswitch_id", HyperswitchWebhookEvents.HYPERSWITCH_WEBHOOK_EVENTS, new OrderField[] { HyperswitchWebhookEvents.HYPERSWITCH_WEBHOOK_EVENTS.HYPERSWITCH_PAYMENT_ID }, false);
     }
 }

--- a/src/main/java/org/killbill/billing/plugin/hyperswitch/dao/gen/Keys.java
+++ b/src/main/java/org/killbill/billing/plugin/hyperswitch/dao/gen/Keys.java
@@ -12,13 +12,14 @@ import org.jooq.types.ULong;
 import org.killbill.billing.plugin.hyperswitch.dao.gen.tables.HyperswitchHppRequests;
 import org.killbill.billing.plugin.hyperswitch.dao.gen.tables.HyperswitchPaymentMethods;
 import org.killbill.billing.plugin.hyperswitch.dao.gen.tables.HyperswitchResponses;
+import org.killbill.billing.plugin.hyperswitch.dao.gen.tables.HyperswitchWebhookEvents;
 import org.killbill.billing.plugin.hyperswitch.dao.gen.tables.records.HyperswitchHppRequestsRecord;
 import org.killbill.billing.plugin.hyperswitch.dao.gen.tables.records.HyperswitchPaymentMethodsRecord;
 import org.killbill.billing.plugin.hyperswitch.dao.gen.tables.records.HyperswitchResponsesRecord;
-
+import org.killbill.billing.plugin.hyperswitch.dao.gen.tables.records.HyperswitchWebhookEventsRecord;
 
 /**
- * A class modelling foreign key relationships and constraints of tables of 
+ * A class modelling foreign key relationships and constraints of tables of
  * the <code>killbill</code> schema.
  */
 @SuppressWarnings({ "all", "unchecked", "rawtypes" })
@@ -31,6 +32,7 @@ public class Keys {
     public static final Identity<HyperswitchHppRequestsRecord, ULong> IDENTITY_HYPERSWITCH_HPP_REQUESTS = Identities0.IDENTITY_HYPERSWITCH_HPP_REQUESTS;
     public static final Identity<HyperswitchPaymentMethodsRecord, ULong> IDENTITY_HYPERSWITCH_PAYMENT_METHODS = Identities0.IDENTITY_HYPERSWITCH_PAYMENT_METHODS;
     public static final Identity<HyperswitchResponsesRecord, ULong> IDENTITY_HYPERSWITCH_RESPONSES = Identities0.IDENTITY_HYPERSWITCH_RESPONSES;
+    public static final Identity<HyperswitchWebhookEventsRecord, ULong> IDENTITY_HYPERSWITCH_WEBHOOK_EVENTS = Identities0.IDENTITY_HYPERSWITCH_WEBHOOK_EVENTS;
 
     // -------------------------------------------------------------------------
     // UNIQUE and PRIMARY KEY definitions
@@ -44,6 +46,8 @@ public class Keys {
     public static final UniqueKey<HyperswitchPaymentMethodsRecord> KEY_HYPERSWITCH_PAYMENT_METHODS_HYPERSWITCH_PAYMENT_METHODS_KB_PAYMENT_ID = UniqueKeys0.KEY_HYPERSWITCH_PAYMENT_METHODS_HYPERSWITCH_PAYMENT_METHODS_KB_PAYMENT_ID;
     public static final UniqueKey<HyperswitchResponsesRecord> KEY_HYPERSWITCH_RESPONSES_PRIMARY = UniqueKeys0.KEY_HYPERSWITCH_RESPONSES_PRIMARY;
     public static final UniqueKey<HyperswitchResponsesRecord> KEY_HYPERSWITCH_RESPONSES_RECORD_ID = UniqueKeys0.KEY_HYPERSWITCH_RESPONSES_RECORD_ID;
+    public static final UniqueKey<HyperswitchWebhookEventsRecord> KEY_HYPERSWITCH_WEBHOOK_EVENTS_PRIMARY = UniqueKeys0.KEY_HYPERSWITCH_WEBHOOK_EVENTS_PRIMARY;
+    public static final UniqueKey<HyperswitchWebhookEventsRecord> KEY_HYPERSWITCH_WEBHOOK_EVENTS_RECORD_ID = UniqueKeys0.KEY_HYPERSWITCH_WEBHOOK_EVENTS_RECORD_ID;
 
     // -------------------------------------------------------------------------
     // FOREIGN KEY definitions
@@ -58,6 +62,7 @@ public class Keys {
         public static Identity<HyperswitchHppRequestsRecord, ULong> IDENTITY_HYPERSWITCH_HPP_REQUESTS = Internal.createIdentity(HyperswitchHppRequests.HYPERSWITCH_HPP_REQUESTS, HyperswitchHppRequests.HYPERSWITCH_HPP_REQUESTS.RECORD_ID);
         public static Identity<HyperswitchPaymentMethodsRecord, ULong> IDENTITY_HYPERSWITCH_PAYMENT_METHODS = Internal.createIdentity(HyperswitchPaymentMethods.HYPERSWITCH_PAYMENT_METHODS, HyperswitchPaymentMethods.HYPERSWITCH_PAYMENT_METHODS.RECORD_ID);
         public static Identity<HyperswitchResponsesRecord, ULong> IDENTITY_HYPERSWITCH_RESPONSES = Internal.createIdentity(HyperswitchResponses.HYPERSWITCH_RESPONSES, HyperswitchResponses.HYPERSWITCH_RESPONSES.RECORD_ID);
+        public static Identity<HyperswitchWebhookEventsRecord, ULong> IDENTITY_HYPERSWITCH_WEBHOOK_EVENTS = Internal.createIdentity(HyperswitchWebhookEvents.HYPERSWITCH_WEBHOOK_EVENTS, HyperswitchWebhookEvents.HYPERSWITCH_WEBHOOK_EVENTS.RECORD_ID);
     }
 
     private static class UniqueKeys0 {
@@ -69,5 +74,7 @@ public class Keys {
         public static final UniqueKey<HyperswitchPaymentMethodsRecord> KEY_HYPERSWITCH_PAYMENT_METHODS_HYPERSWITCH_PAYMENT_METHODS_KB_PAYMENT_ID = Internal.createUniqueKey(HyperswitchPaymentMethods.HYPERSWITCH_PAYMENT_METHODS, "KEY_hyperswitch_payment_methods_hyperswitch_payment_methods_kb_payment_id", new TableField[] { HyperswitchPaymentMethods.HYPERSWITCH_PAYMENT_METHODS.KB_PAYMENT_METHOD_ID }, true);
         public static final UniqueKey<HyperswitchResponsesRecord> KEY_HYPERSWITCH_RESPONSES_PRIMARY = Internal.createUniqueKey(HyperswitchResponses.HYPERSWITCH_RESPONSES, "KEY_hyperswitch_responses_PRIMARY", new TableField[] { HyperswitchResponses.HYPERSWITCH_RESPONSES.RECORD_ID }, true);
         public static final UniqueKey<HyperswitchResponsesRecord> KEY_HYPERSWITCH_RESPONSES_RECORD_ID = Internal.createUniqueKey(HyperswitchResponses.HYPERSWITCH_RESPONSES, "KEY_hyperswitch_responses_record_id", new TableField[] { HyperswitchResponses.HYPERSWITCH_RESPONSES.RECORD_ID }, true);
+        public static final UniqueKey<HyperswitchWebhookEventsRecord> KEY_HYPERSWITCH_WEBHOOK_EVENTS_PRIMARY = Internal.createUniqueKey(HyperswitchWebhookEvents.HYPERSWITCH_WEBHOOK_EVENTS, "KEY_hyperswitch_webhook_events_PRIMARY", new TableField[] { HyperswitchWebhookEvents.HYPERSWITCH_WEBHOOK_EVENTS.RECORD_ID }, true);
+        public static final UniqueKey<HyperswitchWebhookEventsRecord> KEY_HYPERSWITCH_WEBHOOK_EVENTS_RECORD_ID = Internal.createUniqueKey(HyperswitchWebhookEvents.HYPERSWITCH_WEBHOOK_EVENTS, "KEY_hyperswitch_webhook_events_record_id", new TableField[] { HyperswitchWebhookEvents.HYPERSWITCH_WEBHOOK_EVENTS.RECORD_ID }, true);
     }
 }

--- a/src/main/java/org/killbill/billing/plugin/hyperswitch/dao/gen/Tables.java
+++ b/src/main/java/org/killbill/billing/plugin/hyperswitch/dao/gen/Tables.java
@@ -7,7 +7,7 @@ package org.killbill.billing.plugin.hyperswitch.dao.gen;
 import org.killbill.billing.plugin.hyperswitch.dao.gen.tables.HyperswitchHppRequests;
 import org.killbill.billing.plugin.hyperswitch.dao.gen.tables.HyperswitchPaymentMethods;
 import org.killbill.billing.plugin.hyperswitch.dao.gen.tables.HyperswitchResponses;
-
+import org.killbill.billing.plugin.hyperswitch.dao.gen.tables.HyperswitchWebhookEvents;
 
 /**
  * Convenience access to all tables in killbill
@@ -29,4 +29,9 @@ public class Tables {
      * The table <code>killbill.hyperswitch_responses</code>.
      */
     public static final HyperswitchResponses HYPERSWITCH_RESPONSES = HyperswitchResponses.HYPERSWITCH_RESPONSES;
+
+    /**
+     * The table <code>killbill.hyperswitch_webhook_events</code>.
+     */
+    public static final HyperswitchWebhookEvents HYPERSWITCH_WEBHOOK_EVENTS = HyperswitchWebhookEvents.HYPERSWITCH_WEBHOOK_EVENTS;
 }

--- a/src/main/java/org/killbill/billing/plugin/hyperswitch/dao/gen/tables/HyperswitchWebhookEvents.java
+++ b/src/main/java/org/killbill/billing/plugin/hyperswitch/dao/gen/tables/HyperswitchWebhookEvents.java
@@ -1,0 +1,121 @@
+package org.killbill.billing.plugin.hyperswitch.dao.gen.tables;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+
+import org.jooq.Field;
+import org.jooq.ForeignKey;
+import org.jooq.Identity;
+import org.jooq.Index;
+import org.jooq.Name;
+import org.jooq.Record;
+import org.jooq.Schema;
+import org.jooq.Table;
+import org.jooq.TableField;
+import org.jooq.TableOptions;
+import org.jooq.UniqueKey;
+import org.jooq.impl.DSL;
+import org.jooq.impl.SQLDataType;
+import org.jooq.impl.TableImpl;
+import org.jooq.types.ULong;
+import org.killbill.billing.plugin.hyperswitch.dao.gen.Indexes;
+import org.killbill.billing.plugin.hyperswitch.dao.gen.Keys;
+import org.killbill.billing.plugin.hyperswitch.dao.gen.Killbill;
+import org.killbill.billing.plugin.hyperswitch.dao.gen.tables.records.HyperswitchWebhookEventsRecord;
+
+public class HyperswitchWebhookEvents extends TableImpl<HyperswitchWebhookEventsRecord> {
+
+    private static final long serialVersionUID = 1L;
+
+    public static final HyperswitchWebhookEvents HYPERSWITCH_WEBHOOK_EVENTS = new HyperswitchWebhookEvents();
+
+    @Override
+    public Class<HyperswitchWebhookEventsRecord> getRecordType() {
+        return HyperswitchWebhookEventsRecord.class;
+    }
+
+    public final TableField<HyperswitchWebhookEventsRecord, ULong> RECORD_ID = createField(DSL.name("record_id"),
+                                                                                           SQLDataType.BIGINTUNSIGNED.nullable(false).identity(true), this, "");
+
+    public final TableField<HyperswitchWebhookEventsRecord, String> KB_ACCOUNT_ID = createField(DSL.name("kb_account_id"),
+        SQLDataType.CHAR(36).nullable(false), this, "");
+
+    public final TableField<HyperswitchWebhookEventsRecord, String> KB_TENANT_ID = createField(DSL.name("kb_tenant_id"),
+        SQLDataType.CHAR(36).nullable(false), this, "");
+
+    public final TableField<HyperswitchWebhookEventsRecord, String> KB_PAYMENT_ID = createField(DSL.name("kb_payment_id"),
+        SQLDataType.CHAR(36).nullable(false), this, "");
+
+    public final TableField<HyperswitchWebhookEventsRecord, String> KB_PAYMENT_TRANSACTION_ID = createField(
+        DSL.name("kb_payment_transaction_id"), SQLDataType.CHAR(36).nullable(false), this, "");
+
+    public final TableField<HyperswitchWebhookEventsRecord, String> HYPERSWITCH_EVENT_ID = createField(
+        DSL.name("hyperswitch_event_id"), SQLDataType.VARCHAR(255).nullable(false), this, "");
+
+    public final TableField<HyperswitchWebhookEventsRecord, String> HYPERSWITCH_EVENT_TYPE = createField(
+        DSL.name("hyperswitch_event_type"), SQLDataType.VARCHAR(64).nullable(false), this, "");
+
+    public final TableField<HyperswitchWebhookEventsRecord, String> HYPERSWITCH_PAYMENT_ID = createField(
+        DSL.name("hyperswitch_payment_id"), SQLDataType.VARCHAR(255).nullable(false), this, "");
+
+    public final TableField<HyperswitchWebhookEventsRecord, String> EVENT_STATUS = createField(
+        DSL.name("event_status"), SQLDataType.VARCHAR(32).nullable(false), this, "");
+
+    public final TableField<HyperswitchWebhookEventsRecord, String> ERROR_CODE = createField(
+        DSL.name("error_code"), SQLDataType.VARCHAR(64), this, "");
+
+    public final TableField<HyperswitchWebhookEventsRecord, String> ERROR_MESSAGE = createField(
+        DSL.name("error_message"), SQLDataType.VARCHAR(255), this, "");
+
+    public final TableField<HyperswitchWebhookEventsRecord, String> RAW_EVENT = createField(
+        DSL.name("raw_event"), SQLDataType.CLOB, this, "");
+
+    public final TableField<HyperswitchWebhookEventsRecord, LocalDateTime> CREATED_DATE = createField(
+        DSL.name("created_date"), SQLDataType.LOCALDATETIME(0).nullable(false), this, "");
+
+    private HyperswitchWebhookEvents(Name alias, Table<HyperswitchWebhookEventsRecord> aliased) {
+        this(alias, aliased, null);
+    }
+
+    private HyperswitchWebhookEvents(Name alias, Table<HyperswitchWebhookEventsRecord> aliased, Field<?>[] parameters) {
+        super(alias, null, aliased, parameters, DSL.comment(""), TableOptions.table());
+    }
+
+    public HyperswitchWebhookEvents() {
+        this(DSL.name("hyperswitch_webhook_events"), null);
+    }
+
+    @Override
+    public Schema getSchema() {
+        return Killbill.KILLBILL;
+    }
+
+    @Override
+    public List<Index> getIndexes() {
+        return Arrays.<Index>asList(
+            Indexes.HYPERSWITCH_WEBHOOK_EVENTS_PAYMENT,
+            Indexes.HYPERSWITCH_WEBHOOK_EVENTS_TRANSACTION,
+            Indexes.HYPERSWITCH_WEBHOOK_EVENTS_HYPERSWITCH_ID);
+    }
+
+    @Override
+    public Identity<HyperswitchWebhookEventsRecord, ULong> getIdentity() {
+        return Keys.IDENTITY_HYPERSWITCH_WEBHOOK_EVENTS;
+    }
+
+    @Override
+    public UniqueKey<HyperswitchWebhookEventsRecord> getPrimaryKey() {
+        return Keys.KEY_HYPERSWITCH_WEBHOOK_EVENTS_PRIMARY;
+    }
+
+    @Override
+    public HyperswitchWebhookEvents as(String alias) {
+        return new HyperswitchWebhookEvents(DSL.name(alias), this);
+    }
+
+    @Override
+    public HyperswitchWebhookEvents rename(String name) {
+        return new HyperswitchWebhookEvents(DSL.name(name), null);
+    }
+}

--- a/src/main/java/org/killbill/billing/plugin/hyperswitch/dao/gen/tables/records/HyperswitchWebhookEventsRecord.java
+++ b/src/main/java/org/killbill/billing/plugin/hyperswitch/dao/gen/tables/records/HyperswitchWebhookEventsRecord.java
@@ -1,0 +1,126 @@
+package org.killbill.billing.plugin.hyperswitch.dao.gen.tables.records;
+
+import java.time.LocalDateTime;
+import org.jooq.Field;
+import org.jooq.Record1;
+import org.jooq.impl.UpdatableRecordImpl;
+import org.jooq.types.ULong;
+import org.killbill.billing.plugin.hyperswitch.dao.gen.tables.HyperswitchWebhookEvents;
+
+public class HyperswitchWebhookEventsRecord extends UpdatableRecordImpl<HyperswitchWebhookEventsRecord> {
+
+    private static final long serialVersionUID = 1L;
+
+    public void setRecordId(ULong value) {
+        set(0, value);
+    }
+
+    public ULong getRecordId() {
+        return (ULong) get(0);
+    }
+
+    public void setKbAccountId(String value) {
+        set(1, value);
+    }
+
+    public String getKbAccountId() {
+        return (String) get(1);
+    }
+
+    public void setKbTenantId(String value) {
+        set(2, value);
+    }
+
+    public String getKbTenantId() {
+        return (String) get(2);
+    }
+
+    public void setKbPaymentId(String value) {
+        set(3, value);
+    }
+
+    public String getKbPaymentId() {
+        return (String) get(3);
+    }
+
+    public void setKbPaymentTransactionId(String value) {
+        set(4, value);
+    }
+
+    public String getKbPaymentTransactionId() {
+        return (String) get(4);
+    }
+
+    public void setHyperswitchEventId(String value) {
+        set(5, value);
+    }
+
+    public String getHyperswitchEventId() {
+        return (String) get(5);
+    }
+
+    public void setHyperswitchEventType(String value) {
+        set(6, value);
+    }
+
+    public String getHyperswitchEventType() {
+        return (String) get(6);
+    }
+
+    public void setHyperswitchPaymentId(String value) {
+        set(7, value);
+    }
+
+    public String getHyperswitchPaymentId() {
+        return (String) get(7);
+    }
+
+    public void setEventStatus(String value) {
+        set(8, value);
+    }
+
+    public String getEventStatus() {
+        return (String) get(8);
+    }
+
+    public void setErrorCode(String value) {
+        set(9, value);
+    }
+
+    public String getErrorCode() {
+        return (String) get(9);
+    }
+
+    public void setErrorMessage(String value) {
+        set(10, value);
+    }
+
+    public String getErrorMessage() {
+        return (String) get(10);
+    }
+
+    public void setRawEvent(String value) {
+        set(11, value);
+    }
+
+    public String getRawEvent() {
+        return (String) get(11);
+    }
+
+    public void setCreatedDate(LocalDateTime value) {
+        set(12, value);
+    }
+
+    public LocalDateTime getCreatedDate() {
+        return (LocalDateTime) get(12);
+    }
+
+    public HyperswitchWebhookEventsRecord() {
+        super(HyperswitchWebhookEvents.HYPERSWITCH_WEBHOOK_EVENTS);
+    }
+
+    @Override
+    public Record1<ULong> key() {
+        return (Record1) super.key();
+    }
+}

--- a/src/main/resources/ddl.sql
+++ b/src/main/resources/ddl.sql
@@ -17,7 +17,7 @@
 
 /*! SET default_storage_engine=INNODB */;
 
-drop table if exists create table hyperswitch_payment_methods ;
+drop table if exists hyperswitch_payment_methods;
 create table hyperswitch_payment_methods (
   record_id serial
 , kb_account_id char(36) not null
@@ -55,3 +55,24 @@ create table hyperswitch_responses (
 create index hyperswitch_responses_kb_payment_id on hyperswitch_responses(kb_payment_id);
 create index hyperswitch_responses_kb_payment_transaction_id on hyperswitch_responses(kb_payment_transaction_id);
 create index hyperswitch_responses_payment_attmept_id on hyperswitch_responses(payment_attempt_id);
+
+drop table if exists hyperswitch_webhook_events;
+create table hyperswitch_webhook_events (
+  record_id serial
+, kb_account_id char(36) not null
+, kb_tenant_id char(36) not null
+, kb_payment_id char(36) not null
+, kb_payment_transaction_id char(36) not null
+, hyperswitch_event_id varchar(255) not null
+, hyperswitch_event_type varchar(64) not null
+, hyperswitch_payment_id varchar(255) not null
+, event_status varchar(32) not null
+, error_code varchar(64)
+, error_message varchar(255)
+, raw_event longtext default null
+, created_date datetime not null
+, primary key(record_id)
+) /*! CHARACTER SET utf8 COLLATE utf8_bin */;
+create index hyperswitch_webhook_events_payment on hyperswitch_webhook_events(kb_payment_id);
+create index hyperswitch_webhook_events_transaction on hyperswitch_webhook_events(kb_payment_transaction_id);
+create index hyperswitch_webhook_events_hyperswitch_id on hyperswitch_webhook_events(hyperswitch_payment_id);


### PR DESCRIPTION
- Add webhook event handling and processing capability
- Create new table 'hyperswitch_webhook_events' for storing events
- Add event deduplication and status tracking
- Update payment status based on webhook notifications
- Fix typos in environment variable names
- Improve payment status mapping logic
- Add timeouts for API client connections

BREAKING CHANGE: HyperswitchDao constructor now requires Clock parameter